### PR TITLE
Enabling target ED-value precomputation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ __Parameters:__
 * __inputPath (`-f`)__ location of the folder containing folders for each organism. The organism folders have to contain a query and a target folder holding the according fasta files. Default: __..__/input/
 * __outputPath (`-o`)__ location of the output folder. The script will add a folder for each callID. Default: __..__/output/
 * __callID (`-c`)__ is a mandatory ID to differentiate between multiple calls of the script.
+* __withED (`-e`)__ allows the precomputation of target ED-values in order to avoid recomputation.
 
 __IMPORTANT:__ Arguments for IntaRNA can be added at the end of the script call and will be redirected to IntaRNA. python3 calls.py -c "callID"   --"IntaRNA cmdLineArguments"
 
@@ -58,6 +59,10 @@ There are many different controls to assure that no files are overwritten and th
 
 The time (in seconds) and maximal memory usage (in megabyte) required to handle each call is also measured and represented in a table. 
 The tables are also stored in the specified `outputPath`. The individual calls are also logged into a log file.
+
+When `withED` option is set, the ED-values for all targets will be precomputed and stored in a folder `ED-values/'organism'/target_name/`.
+They are then used by all further IntaRNA calls. If the target ED-values are already contained in the given folder, they are directly used without recomputation.
+This option was only tested for ViennaRNA version 2.4.4 and IntaRNA version 2.2.0 and might not work for older versions.
 
 Calls the benchmark.py using the specified callID as benchID.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ __Parameters:__
 * __inputPath (`-f`)__ location of the folder containing folders for each organism. The organism folders have to contain a query and a target folder holding the according fasta files. Default: __..__/input/
 * __outputPath (`-o`)__ location of the output folder. The script will add a folder for each callID. Default: __..__/output/
 * __callID (`-c`)__ is a mandatory ID to differentiate between multiple calls of the script.
-* __arg (`-a`)__ commandline arguments for intaRNA.
+
+__IMPORTANT:__ Arguments for IntaRNA can be added at the end of the script call and will be redirected to IntaRNA. python3 calls.py -c "callID"   --"IntaRNA cmdLineArguments"
 
 This script calls IntaRNA from `intaRNAPath` using the queries and targets for all data sets found within the `inputPath` (see above) and the additional parameterization provided by `arg`.
 The results of IntaRNA are piped to stdout and then into an output file in the `outputPath` where the `callID` is used for according file naming.

--- a/bin/benchmark.py
+++ b/bin/benchmark.py
@@ -15,7 +15,7 @@ def main(argv):
                         , help="path to directory containing the output of the calls script. ")
     parser.add_argument("-b", "--benchID", action="store", dest="benchID", default=""
                         , help="a mandatory ID to differentiate between multiple calls of the script.")
-    args = parser.parse_args();
+    args = parser.parse_args()
 
     # Check whether a benchID was given
     if args.benchID == "":
@@ -29,10 +29,9 @@ def main(argv):
         sys.exit("Error: %s! File not found!" % (args.verified_interactions))
 
     # check whether the benchID is valid (no file with that name exists)
-    outputPath = os.path.join("..", "output", args.benchID, args.outputfile)
+    outputPath = os.path.join(args.directoryPath, args.benchID, args.outputfile)
     if os.path.exists(outputPath):
         sys.exit("A file for this benchID already exists! Exiting...")
-
 
     # Create a dictionary for better accessibility of srna data
     confirmed_hybrids = dict()
@@ -52,7 +51,6 @@ def main(argv):
         else:
             confirmed_hybrids[(spl[0], spl[3])] = [(spl[1], spl[2])]
 
-    print("Starting benchmarking: %s" % args.benchID)
     # Get all directories with needed files and sort them
     srna_files = [x for x in glob.glob(os.path.join(args.directoryPath, args.benchID, "*.csv")) if x.split(os.path.sep)[-1].split("_")[0] in srnaList]
     srna_files.sort()
@@ -77,6 +75,7 @@ def main(argv):
             if (srna_name, organism) in confirmed_hybrids:
                 for confirmed_hybrid in confirmed_hybrids[(srna_name, organism)]:
                     for file in srnaDict[srna_name]:
+                        print(file)
                         df = pd.read_csv(file, sep=";", header=0)
                         df = df.sort_values("E")
 
@@ -91,7 +90,6 @@ def main(argv):
                             outputText += "%s;%s;%s;%s\n" % (srna_name, target_ltag, target_name, intaRNA_rank)
                         except ValueError:
                             continue
-
 
 
     # Check whether the outputFile is empty

--- a/bin/benchmark.py
+++ b/bin/benchmark.py
@@ -75,8 +75,11 @@ def main(argv):
             if (srna_name, organism) in confirmed_hybrids:
                 for confirmed_hybrid in confirmed_hybrids[(srna_name, organism)]:
                     for file in srnaDict[srna_name]:
-                        print(file)
-                        df = pd.read_csv(file, sep=";", header=0)
+                        try:
+                            df = pd.read_csv(file, sep=";", header=0)
+                        except pd.errors.ParserError as err:
+                            errorMessage = "%s      in file %s \n\nPlease contact the IntaRNA development team." % (err, file)
+                            sys.exit(errorMessage)
                         df = df.sort_values("E")
 
                         target_ltag = confirmed_hybrid[0]

--- a/bin/benchmark.py
+++ b/bin/benchmark.py
@@ -103,7 +103,7 @@ def main(argv):
     csv_file.write(outputText)
     csv_file.close()
 
-    print("Finished benchmarking: %s" % benchID)
+    print("Finished benchmarking: %s" % args.benchID)
 
 if __name__ == "__main__":
    main(sys.argv[1:])

--- a/bin/benchmark.py
+++ b/bin/benchmark.py
@@ -1,55 +1,35 @@
 #!/usr/bin/env python3
 # Author: Rick Gelhausen, adapted from perl script by Patrick Wright
-import sys, getopt
+import sys, argparse
 import os.path
 import pandas as pd
 import glob
 
-# help text
-usage= "Call with: python3 benchmark.py -a1 <argument1> -a2 ... \n" \
-       "The following arguments are available: \n" \
-       "--ifile   (-i) : path of the file containing the verified interactions. Default: ../verified_interactions.csv . \n" \
-       "--ofile   (-o) : path of the benchmark outputfile. Default: ./benchmark.csv .\n" \
-       "--pdirs   (-p) : path to directory containing the output of the calls script. Default: ../output \n" \
-       "--benchID (-b) : mandatory benchID used to identify benchmarking. \n" \
-       "--help    (-h) : print usage. \n"
-
 def main(argv):
-    verified_interactions = os.path.join("..", "verified_interactions.csv")
-    directoryPath = os.path.join("..", "output")
-    outputfile = "benchmark.csv"
-    benchID = ""
-    try:
-        opts, args = getopt.getopt(argv,"hi:o:p:b:",["ifile=","ofile=","pdirs=","benchID="])
-    except getopt.GetoptError:
-        print("ERROR! Call <python3 benchmark.py -h> for help!")
-        sys.exit(2)
-    for opt, arg in opts:
-        if opt in ("-h", "--help"):
-            print(usage)
-            sys.exit()
-        elif opt in ("-i", "--ifile"):
-            verified_interactions = arg
-        elif opt in ("-o", "--ofile"):
-            outputfile = arg
-        elif opt in ("-p", "--pdirs"):
-            directoryPath = arg
-        elif opt in ("-b", "--benchID"):
-            benchID = arg
+    parser = argparse.ArgumentParser(description="Benchmark IntaRNA")
+    parser.add_argument("-i", "--ifile", action="store", dest="verified_interactions", default=os.path.join("..", "verified_interactions.csv")
+                        , help= "location of the file containing the verified interactions.")
+    parser.add_argument("-o", "--ofile", action="store", dest="outputfile", default=os.path.join(".", "benchmark.csv")
+                        , help="path of the benchmark outputfile.")
+    parser.add_argument("-p", "--pdirs", action="store", dest="directoryPath", default=os.path.join("..", "output")
+                        , help="path to directory containing the output of the calls script. ")
+    parser.add_argument("-b", "--benchID", action="store", dest="benchID", default=""
+                        , help="a mandatory ID to differentiate between multiple calls of the script.")
+    args = parser.parse_args();
 
     # Check whether a benchID was given
-    if benchID == "":
+    if args.benchID == "":
         sys.exit("No benchID was specified! Please specify a benchID using -b <name> or --benchID=<name>")
 
     # read verified interactions
-    if os.path.exists(verified_interactions) == True:
-        with open(verified_interactions) as data:
+    if os.path.exists(args.verified_interactions) == True:
+        with open(args.verified_interactions) as data:
             tempHybrid = [line.strip() for line in data]
     else:
-        sys.exit("Error: %s! File not found!" % (verified_interactions))
+        sys.exit("Error: %s! File not found!" % (args.verified_interactions))
 
     # check whether the benchID is valid (no file with that name exists)
-    outputPath = os.path.join("..", "output", benchID, outputfile)
+    outputPath = os.path.join("..", "output", args.benchID, args.outputfile)
     if os.path.exists(outputPath):
         sys.exit("A file for this benchID already exists! Exiting...")
 
@@ -72,14 +52,14 @@ def main(argv):
         else:
             confirmed_hybrids[(spl[0], spl[3])] = [(spl[1], spl[2])]
 
-    print("Starting benchmarking: %s" % benchID)
+    print("Starting benchmarking: %s" % args.benchID)
     # Get all directories with needed files and sort them
-    srna_files = [x for x in glob.glob(os.path.join(directoryPath, benchID, "*.csv")) if x.split(os.path.sep)[-1].split("_")[0] in srnaList]
+    srna_files = [x for x in glob.glob(os.path.join(args.directoryPath, args.benchID, "*.csv")) if x.split(os.path.sep)[-1].split("_")[0] in srnaList]
     srna_files.sort()
 
     # Check whether the needed files for the benchmarking exist
     if srna_files == []:
-        sys.exit("Error!!! No files found for benchmarking ID %s" % benchID)
+        sys.exit("Error!!! No files found for benchmarking ID %s" % args.benchID)
 
     # Create a dictionary from the srna_files for better access
     srnaDict = dict()
@@ -89,7 +69,7 @@ def main(argv):
         else:
             srnaDict[srna] = [x for x in srna_files if srna in x]
 
-    outputText= "srna_name;target_ltag;target_name;%s_intarna_rank\n" % benchID
+    outputText= "srna_name;target_ltag;target_name;%s_intarna_rank\n" % args.benchID
 
     # determine the rank of intaRNA given the confirmed hybrids
     for srna_name in srnaList:

--- a/bin/calls.py
+++ b/bin/calls.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # NOTE: python > 3.2 needed
 # Author: Rick Gelhausen
-import sys, getopt
+import sys, argparse
 import os
 import glob
 import shlex
@@ -16,86 +16,66 @@ from subprocess import PIPE
 #                                                                                                                      #
 ########################################################################################################################
 
-# help text
-usage= "Call with: python3 calls.py -a1 <argument1> -a2 ..." \
-       "The following arguments are available:\n" \
-       "--ifile  (-i) : path where the intaRNA executable lies. Default: ../IntaRNA/src/bin . \n" \
-       "--ffile  (-f) : input folder containing the faster files required. Default: ./input .\n" \
-       "--ofile  (-o) : output folder.\n" \
-       "--arg    (-a) : command line arguments applied to the intaRNA query. \n" \
-       "--callID (-c) : mandatory callID used to identify call. \n" \
-       "--callsOnly (-n) : only generate the calls and store in the logfile but not start processes. \n" \
-       "--help   (-h) : print this usage. \n"
-
 
 # Run a subprocess with the given call and provide process statistics
 def runSubprocess(callArgs):
-    with Popen(callcallArgs) as process:
+    with Popen(callArgs) as process:
         # wait for call to finish and get statistics
         ru = os.wait4(process.pid, 0)[2]
     # Return time and memory usage
     return ru.ru_utime, ru.ru_maxrss
 
 def main(argv):
-    intaRNAPath = os.path.join("..", "..", "IntaRNA", "src", "bin", "")
-    outputPath = os.path.join("..", "output")
-    inputPath = os.path.join("..", "input")
-    commandLineArguments = ""
-    callID = ""
-    noJobStart =  False
+    parser = argparse.ArgumentParser(description="Call script for benchmarking IntaRNA. IntaRNA commandLineArguments can be added at the end of the call."
+                                                 "python3 calls.py -c <callID>  --<IntaRNA arguments>")
+    parser.add_argument("-i", "--ifile", action="store", dest="intaRNAPath", default=os.path.join("..", "..", "IntaRNA", "src", "bin", "")
+                        , help="the location of the intaRNA executable. Default: ../../IntaRNA/src/bin .")
+    parser.add_argument("-f", "--ffile", action="store", dest="inputPath", default=os.path.join("..", "input")
+                        , help="input folder containing the required fasta files. Default: ./input")
+    parser.add_argument("-o", "--ofile", action="store", dest="outputPath", default=os.path.join("..", "output")
+                        , help="location of the output folder.")
+    #parser.add_argument("-a", "--arg", help="command line arguments applied to the intaRNA query.")
+    parser.add_argument("-c", "--callID", action="store", dest="callID", default=""
+                        , help="a mandatory ID to differentiate between multiple calls of the script.")
+    parser.add_argument("-n", "--callsOnly", action="store_true", dest="noJobStart", default=False
+                        , help="only generate the calls and store in the logfile but not start processes.")
 
-    # commandline parsing
-    try:
-        opts, args = getopt.getopt(argv,"hni:o:f:a:c:",["ifile=", "ofile=", "ffile=", "arg=", "callID=", "callsOnly", "help"])
-    except getopt.GetoptError:
-        print("ERROR! Call <python3 calls.py -h> for help")
-        sys.exit(2)
-    for opt, arg in opts:
-        if opt in ("-h", "--help"):
-            print(usage)
-            sys.exit()
-        if opt in ("-n", "--callsOnly"):
-            noJobStart = True
-        elif opt in ("-i", "--ifile"):
-            intaRNAPath = arg
-        elif opt in ("-o", "--ofile"):
-            outputPath = arg
-        elif opt in ("-f", "--ffile"):
-            inputPath = arg
-        elif opt in ("-a", "--arg"):
-            commandLineArguments = arg
-        elif opt in ("-c", "--callID"):
-            callID = arg
+    #   Warning  Prefix matching rules apply to parse_known_args().
+    #  The parser may consume an option even if it’s just a prefix of one of its known options, instead of leaving it in the remaining arguments list.
+    args, cmdLineArgs = parser.parse_known_args()
+
+    # Remaining argument options are used for IntaRNA
+    cmdLineArgs = " ".join(cmdLineArgs)
 
     # Check whether a callID was given
-    if callID == "":
+    if args.callID == "":
         sys.exit("No callID was specified! Please specify a callID using -c <name> or --callID=<name>")
 
     # Check whether intaRNA path exists
-    if not os.path.exists(intaRNAPath):
+    if not os.path.exists(args.intaRNAPath):
         sys.exit("Error!!! IntaRNA filePath does not exist! Please specify it using -i <intaRNApath>!")
 
     # Create outputFolder for this callID if not existing
-    if not os.path.exists(os.path.join(outputPath, callID)):
-        os.makedirs(os.path.join(outputPath, callID))
+    if not os.path.exists(os.path.join(args.outputPath, args.callID)):
+        os.makedirs(os.path.join(args.outputPath, args.callID))
     else:
-        sys.exit("Error!!! A directory for callID %s already exists!" % callID)
+        sys.exit("Error!!! A directory for callID %s already exists!" % args.callID)
 
     # Organisms
-    organisms = [x.split(os.path.sep)[-1] for x in glob.glob(os.path.join(inputPath,"*")) if os.path.isdir(x)]
+    organisms = [x.split(os.path.sep)[-1] for x in glob.glob(os.path.join(args.inputPath,"*")) if os.path.isdir(x)]
     if organisms == []:
         sys.exit("Input folder is empty!")
 
     # Filepaths
-    callLogFilePath = os.path.join(outputPath, callID, "calls.txt")
-    timeLogFilePath = os.path.join(outputPath, callID, "runTime.csv")
-    memoryLogFilePath = os.path.join(outputPath, callID, "memoryUsage.csv")
+    callLogFilePath = os.path.join(args.outputPath, args.callID, "calls.txt")
+    timeLogFilePath = os.path.join(args.outputPath, args.callID, "runTime.csv")
+    memoryLogFilePath = os.path.join(args.outputPath, args.callID, "memoryUsage.csv")
 
     for organism in organisms:
         # check if query and target folder exist
-        if not os.path.exists(os.path.join(inputPath, organism, "query")):
+        if not os.path.exists(os.path.join(args.inputPath, organism, "query")):
             sys.exit("Error!!! Could not find query path for %s!" % organism)
-        if not os.path.exists(os.path.join(inputPath, organism, "target")):
+        if not os.path.exists(os.path.join(args.inputPath, organism, "target")):
             sys.exit("Error!!! Could not find target path for %s!" % organism)
 
         fastaFileEndings = [".fasta", ".fa"]
@@ -103,8 +83,8 @@ def main(argv):
         srna_files = []
         target_files = []
         for ending in fastaFileEndings:
-            srna_files.extend(glob.glob(os.path.join(inputPath, organism, "query", "*" + ending)))
-            target_files.extend(glob.glob(os.path.join(inputPath, organism, "target", "*" + ending)))
+            srna_files.extend(glob.glob(os.path.join(args.inputPath, organism, "query", "*" + ending)))
+            target_files.extend(glob.glob(os.path.join(args.inputPath, organism, "target", "*" + ending)))
 
         # Sort input
         srna_files.sort()
@@ -121,26 +101,26 @@ def main(argv):
             target_name = target_file.split(os.path.sep)[-1].split(".")[0]
             # Variables to create the timeLog table
             header = "callID;target_name;Organism"
-            timeLine = "%s;%s;%s" % (callID, target_name, organism)
-            memoryLine = "%s;%s;%s" % (callID, target_name, organism)
+            timeLine = "%s;%s;%s" % (args.callID, target_name, organism)
+            memoryLine = "%s;%s;%s" % (args.callID, target_name, organism)
 
             for srna_file in srna_files:
                 srna_name = srna_file.split(os.path.sep)[-1].split("_")[0]
                 header += ";%s" % srna_name
 
                 # Outputfilepath
-                out = os.path.join(outputPath, callID, srna_name + "_" + target_name + ".csv")
+                out = os.path.join(args.outputPath, args.callID, srna_name + "_" + target_name + ".csv")
 
                 # IntaRNA call
-                call = intaRNAPath +"/"+ "IntaRNA" + " -q " + srna_file \
+                call = args.intaRNAPath +"/"+ "IntaRNA" + " -q " + srna_file \
                                                + " -t " + target_file \
                                                + " --out " + out \
                                                + " --outMode C"  \
-                                               + " " + commandLineArguments
+                                               + " " + cmdLineArgs
 
                 print(call, file=open(callLogFilePath, "a"))
 
-                if not noJobStart:
+                if not args.noJobStart:
                     # split call for subprocess creation
                     callArgs = shlex.split(call)
                     # do call and get process information
@@ -166,9 +146,9 @@ def main(argv):
             print(memoryLine, file=open(memoryLogFilePath, "a"))
 
 
-    if not noJobStart:
+    if not args.noJobStart:
         # Start benchmarking for this callID
-        callBenchmark = "python3 benchmark.py -b %s" % (callID)
+        callBenchmark = "python3 benchmark.py -b %s" % (args.callID)
         with Popen(shlex.split(callBenchmark), stdout=PIPE) as process:
             print(str(process.stdout.read(), "utf-8"))
 

--- a/bin/calls.py
+++ b/bin/calls.py
@@ -112,11 +112,11 @@ def main(argv):
                 out = os.path.join(args.outputPath, args.callID, srna_name + "_" + target_name + ".csv")
 
                 # IntaRNA call
-                call = args.intaRNAPath +"/"+ "IntaRNA" + " -q " + srna_file \
-                                               + " -t " + target_file \
-                                               + " --out " + out \
-                                               + " --outMode C"  \
-                                               + " " + cmdLineArgs
+                call = args.intaRNAPath + "IntaRNA" + " -q " + srna_file \
+                                                    + " -t " + target_file \
+                                                    + " --out " + out \
+                                                    + " --outMode C "  \
+                                                    + cmdLineArgs
 
                 print(call, file=open(callLogFilePath, "a"))
 

--- a/bin/clearAll.py
+++ b/bin/clearAll.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Author: Rick Gelhausen
-import sys, getopt
+import sys, argparse
 import os
 import glob
 import shutil
@@ -28,29 +28,19 @@ def deleteFolders(foldersToDeleteList):
             print(e)
 
 def main(argv):
-    inFilePath = os.path.join("..", "output")
-    callID = ""
 
-    # commandline parsing
-    try:
-        opts, args = getopt.getopt(argv,"hf:c:",["ffile=","callID="])
-    except getopt.GetoptError:
-        print("ERROR! Call <python3 clearAll.py -h> for help")
-        sys.exit(2)
-    for opt, arg in opts:
-        if opt in ("-h", "--help"):
-            print(usage)
-            sys.exit()
-        elif opt in ("-f", "--ffile"):
-            inFilePath = arg
-        elif opt in ("-c", "--callID"):
-            callID = arg
+    parser = argparse.ArgumentParser(description="Script for clearing benchmarks")
+    parser.add_argument("-f", "--ffile", action="store", dest="inFilePath", default=os.path.join("..", "output")
+                        , help="the location of the intaRNA executable. Default: ../../IntaRNA/src/bin .")
+    parser.add_argument("-c", "--callID", action="store", dest="callID", default=os.path.join("")
+                        , help="Allows clearing only certain callIDs. Specify multiple callIDs with callID1/callID2/...")
+    args = parser.parse_args()
 
     # read all files
-    allFolders = glob.glob(os.path.join(inFilePath, "*"))
+    allFolders = glob.glob(os.path.join(args.inFilePath, "*"))
 
     # clear all created files
-    if callID == "":
+    if args.callID == "":
         for benchFolder in allFolders:
             print("File: %s flagged for delete!" % (benchFolder))
 
@@ -62,10 +52,10 @@ def main(argv):
             sys.exit("Aborting!!!")
     else:
         callIDs = []
-        if "/" in callID:
-            callIDs = callID.split("/")
+        if "/" in args.callID:
+            callIDs = args.callID.split("/")
         else:
-            callIDs.append(callID)
+            callIDs.append(args.callID)
 
         foldersToDelete = []
         for c in callIDs:

--- a/bin/mergeBenchmarks.py
+++ b/bin/mergeBenchmarks.py
@@ -61,7 +61,7 @@ def main(argv):
                         , help=" path to the benchmark folders.")
     parser.add_argument("-b", "--benchID", action="store", dest="benchID", default=""
                         , help="a mandatory ID to differentiate between multiple calls of the script. Specify multiple ones by using benchID1/benchID2/...")
-    parser.add_argument("-a", "--all", action="store_true", dest="benchID", default=False
+    parser.add_argument("-a", "--all", action="store_true", dest="all", default=False
                         , help="When set all available benchmark folders will be merged.")
     args = parser.parse_args();
 
@@ -73,7 +73,7 @@ def main(argv):
     allIDfolders = [x for x in glob.glob(os.path.join(args.benchFilePath, "*")) if os.path.isdir(x)]
     print(allIDfolders)
 
-    if not all:
+    if not args.all:
         # Check whether a benchID was given
         if args.benchID == "" or not "/" in args.benchID:
             sys.exit("Please specify atleast two benchIDs using python3 mergeBenchmarks -b <name1/name2>")

--- a/bin/mergeBenchmarks.py
+++ b/bin/mergeBenchmarks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Author: Rick Gelhausen
-import sys, getopt
+import sys, argparse
 import os.path
 import glob
 import pandas as pd
@@ -12,16 +12,6 @@ import pandas as pd
 #                                        Merge all or specific callIDs                                                 #
 #                                                                                                                      #
 ########################################################################################################################
-
-# help text
-usage = "Call with: python3 mergeBenchmarks.py -a1 <argument1> -a2 ... \n" \
-        "The following arguments are available: \n" \
-        "--ofile   (-o) : path and name of outputfile. MANDATORY. .\n" \
-        "--bdirs   (-d) : path to the benchmark folder. Default: ./output \n" \
-        "--benchID (-b) : benchIDs to be merged. benchID1/benchID2/... \n" \
-        "--all     (-a) : if parameter is set no benchID needs to be specified. Every ID is used automatically.\n" \
-        "--help    (-h) : print usage. \n"
-
 
 # This method assumes an equal setup of all benchmark files
 def mergeBenchmarks(benchList, outputPath):
@@ -62,67 +52,55 @@ def mergeLogFiles(benchIDList, benchPath, outputpath):
 
 
 def main(argv):
-    benchFilePath = os.path.join("..", "output")
-    infileName = "benchmark.csv"
-    outputfile = ""
-    benchID = ""
-    all = False
-    try:
-        opts, args = getopt.getopt(argv, "hi:o:d:b:a", ["ifile=", "ofile=", "bdirs=", "benchID="])
-    except getopt.GetoptError:
-        print("ERROR! Call <python3 mergeBenchmarks.py -h> for help!")
-        sys.exit(2)
-    for opt, arg in opts:
-        if opt in ("-h", "--help"):
-            print(usage)
-            sys.exit()
-        elif opt in ("-i", "--ifile"):
-            infileName = arg
-        elif opt in ("-o", "--ofile"):
-            outputfile = arg
-        elif opt in ("-d", "--bdirs"):
-            benchFilePath = arg
-        elif opt in ("-b", "--benchID"):
-            benchID = arg
-        elif opt in ("-a", "--all"):
-            all = True
+    parser = argparse.ArgumentParser(description="Script to merge multiple benchmarks")
+    parser.add_argument("-i", "--ifile", action="store", dest="infileName", default=os.path.join("benchmark.csv")
+                        , help="The default name of the result file of the benchmarking script")
+    parser.add_argument("-o", "--ofile", action="store", dest="outputfile", default=os.path.join("")
+                        , help="Mandatory path and name for the outputfile.")
+    parser.add_argument("-d", "--bdirs", action="store", dest="benchFilePath", default=os.path.join("..", "output")
+                        , help=" path to the benchmark folders.")
+    parser.add_argument("-b", "--benchID", action="store", dest="benchID", default=""
+                        , help="a mandatory ID to differentiate between multiple calls of the script. Specify multiple ones by using benchID1/benchID2/...")
+    parser.add_argument("-a", "--all", action="store_true", dest="benchID", default=False
+                        , help="When set all available benchmark folders will be merged.")
+    args = parser.parse_args();
 
     # Enforce an outputfile path/name.csv
-    if outputfile == "":
+    if args.outputfile == "":
         sys.exit("Please use: python3 mergeBenchmarks.py -o <path/name.csv> to specify an output file!")
 
     # read all benchfiles in folder
-    allIDfolders = [x for x in glob.glob(os.path.join(benchFilePath, "*")) if os.path.isdir(x)]
+    allIDfolders = [x for x in glob.glob(os.path.join(args.benchFilePath, "*")) if os.path.isdir(x)]
     print(allIDfolders)
 
     if not all:
         # Check whether a benchID was given
-        if benchID == "" or not "/" in benchID:
+        if args.benchID == "" or not "/" in args.benchID:
             sys.exit("Please specify atleast two benchIDs using python3 mergeBenchmarks -b <name1/name2>")
 
         toBeMerged = []
         existingBenchIDs = []
-        benchIDs = benchID.split("/")
+        benchIDs = args.benchID.split("/")
         for bID in benchIDs:
             for folder in allIDfolders:
                 if bID == folder.split(os.path.sep)[-1]:
-                    toBeMerged.append(os.path.join(folder, infileName))
+                    toBeMerged.append(os.path.join(folder, args.infileName))
                     existingBenchIDs.append(bID)
 
         if len(toBeMerged) > 1:
-            mergeBenchmarks(toBeMerged, outputfile)
-            mergeLogFiles(existingBenchIDs, benchFilePath, outputfile)
+            mergeBenchmarks(toBeMerged, args.outputfile)
+            mergeLogFiles(existingBenchIDs, args.benchFilePath, args.outputfile)
         else:
             sys.exit("Not enough files to merge!")
 
     # Merge all
     else:
         if len(allIDfolders) > 1:
-            allIDfolders = [os.path.join(x, infileName) for x in allIDfolders]
+            allIDfolders = [os.path.join(x, args.infileName) for x in allIDfolders]
 
-            mergeBenchmarks(allIDfolders, outputfile)
+            mergeBenchmarks(allIDfolders, args.outputfile)
             allIDs = [x.split(os.path.sep)[-2] for x in allIDfolders]
-            mergeLogFiles(allIDs, benchFilePath, outputfile)
+            mergeLogFiles(allIDs, args.benchFilePath, args.outputfile)
         else:
             sys.exit("Not enough files to merge!")
 

--- a/bin/plot_performance.py
+++ b/bin/plot_performance.py
@@ -20,11 +20,11 @@ def main(argv):
     parser = argparse.ArgumentParser(description="Script for plotting the benchmark results")
     parser.add_argument("-i", "--ifile", action="store", dest="benchmarkFile", default=os.path.join("")
                         , help="Mandatory benchmark file to be used for plotting.")
-    parser.add_argument("-o", "--ofile", action="store", dest="outFile", default=os.path.join("", "output", "intaRNA2_benchmark.pdf")
+    parser.add_argument("-o", "--ofile", action="store", dest="outFile", default=os.path.join("..", "output", "intaRNA2_benchmark.pdf")
                         , help="the path of the outputFilePath.")
     parser.add_argument("-s", "--sep", action="store", dest="separator", default=";"
                         , help="specify the separator used by the benchmark file.")
-    parser.add_argument("-e", "--end", action="store", dest="end", default=200
+    parser.add_argument("-e", "--end", action="store", dest="end", default=200, type=int
                         , help="The amount of predictions considered for plotting.")
     parser.add_argument("-x", "--xlim", action="store", dest="xlim", default=""
                         , help="specify a xlim for the output.")
@@ -57,7 +57,7 @@ def main(argv):
             # Plot the data
             keys = rankDictionary.keys()
             for key in keys:
-                plt.plot(rankDictionary[key], label=key)
+                plt.plot(rankDictionary[key], label=key.replace("_intarna_rank", ""))
 
             plt.legend(loc="lower right")
             plt.xlabel("# Target predictions per sRNA")

--- a/bin/plot_performance.py
+++ b/bin/plot_performance.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 # Author: Rick Gelhausen
 
-import sys, getopt
+import sys, argparse
 import os
 import pandas as pd
 import matplotlib
+
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
@@ -15,54 +16,28 @@ import matplotlib.pyplot as plt
 #                                                                                                                      #
 ########################################################################################################################
 
-# help text
-usage = "Call with: python3 plot_performance.py -a1 <argument1> -a2 ..." \
-        "The following arguments are available:\n" \
-        "--ifile  (-i) : Benchmark file to be used for plotting. MANDATORY . \n" \
-        "--ofile  (-o) : outputFilePath. Default: ../output/intaRNA2_benchmark.pdf \n" \
-        "--sep    (-s) : specify the separator used by the benchmark file. Default ';'\n" \
-        "--end    (-e) : endpoint of the run. Default: 200 \n" \
-        "--xlim   (-x) : specify a xlim for the output. x_start/x_end .\n" \
-        "--ylim   (-y) : specify a ylim for the output. y_start/y_end .\n" \
-        "--help   (-h) : print this usage. \n"
-
-
 def main(argv):
-    benchmarkFile = ""
-    outFile = os.path.join("..", "output", "intaRNA2_benchmark.pdf")
-    separator = ";"
-    end = 200
-    xlim = ""
-    ylim = ""
-    # commandline parsing
-    try:
-        opts, args = getopt.getopt(argv, "hi:o:s:e:x:y:", ["ifile=","ofile=", "sep=", "end="])
-    except getopt.GetoptError:
-        print("ERROR! Call <python3 plot_performance.py -h> for help")
-        sys.exit(2)
-    for opt, arg in opts:
-        if opt in ("-h", "--help"):
-            print(usage)
-            sys.exit()
-        elif opt in ("-i", "--ifile"):
-            benchmarkFile = arg
-        elif opt in ("-o", "--ofile"):
-            outFile = arg
-        elif opt in ("-s", "--sep"):
-            separator = arg
-        elif opt in ("-e", "--end"):
-            end = arg
-        elif opt in ("-x", "--xlim"):
-            xlim = arg
-        elif opt in ("-y", "--ylim"):
-            ylim = arg
+    parser = argparse.ArgumentParser(description="Script for plotting the benchmark results")
+    parser.add_argument("-i", "--ifile", action="store", dest="benchmarkFile", default=os.path.join("")
+                        , help="Mandatory benchmark file to be used for plotting.")
+    parser.add_argument("-o", "--ofile", action="store", dest="outFile", default=os.path.join("", "output", "intaRNA2_benchmark.pdf")
+                        , help="the path of the outputFilePath.")
+    parser.add_argument("-s", "--sep", action="store", dest="separator", default=";"
+                        , help="specify the separator used by the benchmark file.")
+    parser.add_argument("-e", "--end", action="store", dest="end", default=200
+                        , help="The amount of predictions considered for plotting.")
+    parser.add_argument("-x", "--xlim", action="store", dest="xlim", default=""
+                        , help="specify a xlim for the output.")
+    parser.add_argument("-y", "--ylim", action="store", dest="ylim", default=""
+                        , help="specify a ylim for the output.")
+    args = parser.parse_args()
 
-    if benchmarkFile == "":
+    if args.benchmarkFile == "":
         sys.exit("Please specify a benchmark.csv with: python3 plot_performance.py -i <filename.csv> !")
 
 
-    if os.path.exists(benchmarkFile):
-        benchDF = pd.read_csv(benchmarkFile, sep=separator, header=0)
+    if os.path.exists(args.benchmarkFile):
+        benchDF = pd.read_csv(args.benchmarkFile, sep=args.separator, header=0)
         prefix = ["srna_name", "target_ltag", "target_name"]
         intarnaIDs = [x for x in benchDF.columns if x not in prefix]
         print(intarnaIDs)
@@ -73,7 +48,7 @@ def main(argv):
             rankDictionary[entry] = []
 
         # Get the ranks for each callID
-        for i in range(1, end):
+        for i in range(1, args.end):
             for id in intarnaIDs:
                 rankDictionary[id].append(len(benchDF[benchDF[id] <= i]))
 
@@ -88,16 +63,16 @@ def main(argv):
             plt.xlabel("# Target predictions per sRNA")
             plt.ylabel("# True positive")
 
-            if xlim != "" and "/" in xlim:
-                plt.xlim(int(xlim.split("/")[0]), int(xlim.split("/")[1]))
-            if ylim != "" and "/" in ylim:
-                plt.ylim(int(ylim.split("/")[0]), int(ylim.split("/")[1]))
+            if args.xlim != "" and "/" in args.xlim:
+                plt.xlim(int(args.xlim.split("/")[0]), int(args.xlim.split("/")[1]))
+            if args.ylim != "" and "/" in args.ylim:
+                plt.ylim(int(args.ylim.split("/")[0]), int(args.ylim.split("/")[1]))
 
-            plt.savefig(outFile)
+            plt.savefig(args.outFile)
             plt.close()
 
     else:
-        sys.exit("Could not find %s!" % benchmarkFile)
+        sys.exit("Could not find %s!" % args.benchmarkFile)
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
- Changed `getopt` to `argparse` in order to improve the commandline parsing.
- `IntaRNA commandLineArguments` can now be added at the end of the python call and will be parsed correctly.
- Changed `calls.py` script in order to allow the precomputation of target ED-values, that can then be used in further calls to improve the runtime.
- Minor fixes to comments.
- Updated `README.md` .